### PR TITLE
Fix: Escape newlines for Astro v4

### DIFF
--- a/src/remarkCodeBlock.ts
+++ b/src/remarkCodeBlock.ts
@@ -44,7 +44,14 @@ export default function makeRemarkCodeBlocks({ tagName }: CodeBlocksOptions) {
                             );
                         }
                         const props = {
-                            code: node.value,
+                            code: node.value.replace(
+                                /\r?\n/g,
+                                (match: string) => {
+                                    return match === '\n'
+                                        ? '\\n'
+                                        : '\\r\\n';
+                                }
+                            ),
                             lang,
                             ...metaAttributes,
                         };


### PR DESCRIPTION
Fixes #3 by escaping newline characters at the end of each line. Works for MDX with both LF and CRLF for end of line sequences.

⚠️ **Breaking change**: Astro components must manually unescape the code string, for example:
```jsx
import { Code } from "astro:components";

const { lang } = Astro.props;
const code = Astro.props.code.replaceAll('\\r', '\r').replaceAll('\\n', '\n');
---
<Code {code} {lang} />
```

More details here: withastro/astro#10888